### PR TITLE
Add Github Actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,13 @@
 name: Node CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - 'features/*'
+      - 'fix/*'
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This PR adds Github Actions.

By adding this we will have CI/CD for all pull requests (shown below), for `master`, `develop`, `features/*` and `fix/*` branches. It runs build for node `8.x`, `10.x`, `12.x` and uses `yarn`. Runs the following commands:

- `yarn` (to install packages)
- `yarn build` (to build)
- `yarn test`

*PS: This will not build, because it is missing a script for `test`